### PR TITLE
Add support for DVD SCSI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NXDK_DIR = $(CURDIR)/../nxdk
 NXDK_NET = y
 
-XBE_TITLE = triangle
+XBE_TITLE = nxdk-rdt
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(wildcard $(CURDIR)/*.c)
 SHADER_OBJS = ps.inl vs.inl

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ SHADER_OBJS = ps.inl vs.inl
 
 SRCS += $(CURDIR)/lib/protobuf-c/protobuf-c.c
 
-CFLAGS_EXTRA += -I$(CURDIR)
-CFLAGS_EXTRA += -I$(CURDIR)/lib
-
 include $(NXDK_DIR)/Makefile
+
+CFLAGS += -I$(CURDIR)
+CFLAGS += -I$(CURDIR)/lib
 
 .PHONY:clean_local
 clean_local:

--- a/assert.h
+++ b/assert.h
@@ -1,0 +1,1 @@
+#define assert(x)

--- a/assert.h
+++ b/assert.h
@@ -1,1 +1,6 @@
+#ifndef ASSERT_H
+#define ASSERT_H
+
 #define assert(x)
+
+#endif

--- a/dbg.pb-c.c
+++ b/dbg.pb-c.c
@@ -174,7 +174,7 @@ const ProtobufCMessageDescriptor dbg__sys_info__descriptor =
   (ProtobufCMessageInit) dbg__sys_info__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue dbg__request__type__enum_values_by_number[10] =
+static const ProtobufCEnumValue dbg__request__type__enum_values_by_number[12] =
 {
   { "SYSINFO", "DBG__REQUEST__TYPE__SYSINFO", 0 },
   { "REBOOT", "DBG__REQUEST__TYPE__REBOOT", 1 },
@@ -185,20 +185,24 @@ static const ProtobufCEnumValue dbg__request__type__enum_values_by_number[10] =
   { "DEBUG_PRINT", "DBG__REQUEST__TYPE__DEBUG_PRINT", 6 },
   { "SHOW_DEBUG_SCREEN", "DBG__REQUEST__TYPE__SHOW_DEBUG_SCREEN", 7 },
   { "SHOW_FRONT_SCREEN", "DBG__REQUEST__TYPE__SHOW_FRONT_SCREEN", 8 },
-  { "COUNT", "DBG__REQUEST__TYPE__COUNT", 9 },
+  { "SCSI_DVD_IN", "DBG__REQUEST__TYPE__SCSI_DVD_IN", 9 },
+  { "SCSI_DVD_OUT", "DBG__REQUEST__TYPE__SCSI_DVD_OUT", 10 },
+  { "COUNT", "DBG__REQUEST__TYPE__COUNT", 11 },
 };
 static const ProtobufCIntRange dbg__request__type__value_ranges[] = {
-{0, 0},{0, 10}
+{0, 0},{0, 12}
 };
-static const ProtobufCEnumValueIndex dbg__request__type__enum_values_by_name[10] =
+static const ProtobufCEnumValueIndex dbg__request__type__enum_values_by_name[12] =
 {
-  { "COUNT", 9 },
+  { "COUNT", 11 },
   { "DEBUG_PRINT", 6 },
   { "FREE", 3 },
   { "MALLOC", 2 },
   { "MEM_READ", 4 },
   { "MEM_WRITE", 5 },
   { "REBOOT", 1 },
+  { "SCSI_DVD_IN", 9 },
+  { "SCSI_DVD_OUT", 10 },
   { "SHOW_DEBUG_SCREEN", 7 },
   { "SHOW_FRONT_SCREEN", 8 },
   { "SYSINFO", 0 },
@@ -210,15 +214,15 @@ const ProtobufCEnumDescriptor dbg__request__type__descriptor =
   "Type",
   "Dbg__Request__Type",
   "dbg",
-  10,
+  12,
   dbg__request__type__enum_values_by_number,
-  10,
+  12,
   dbg__request__type__enum_values_by_name,
   1,
   dbg__request__type__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor dbg__request__field_descriptors[5] =
+static const ProtobufCFieldDescriptor dbg__request__field_descriptors[7] =
 {
   {
     "type",
@@ -280,9 +284,35 @@ static const ProtobufCFieldDescriptor dbg__request__field_descriptors[5] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "command",
+    6,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_BYTES,
+    offsetof(Dbg__Request, has_command),
+    offsetof(Dbg__Request, command),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "buffer",
+    7,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_BYTES,
+    offsetof(Dbg__Request, has_buffer),
+    offsetof(Dbg__Request, buffer),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned dbg__request__field_indices_by_name[] = {
   2,   /* field[2] = address */
+  6,   /* field[6] = buffer */
+  5,   /* field[5] = command */
   1,   /* field[1] = msg */
   3,   /* field[3] = size */
   0,   /* field[0] = type */
@@ -291,7 +321,7 @@ static const unsigned dbg__request__field_indices_by_name[] = {
 static const ProtobufCIntRange dbg__request__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 5 }
+  { 0, 7 }
 };
 const ProtobufCMessageDescriptor dbg__request__descriptor =
 {
@@ -301,7 +331,7 @@ const ProtobufCMessageDescriptor dbg__request__descriptor =
   "Dbg__Request",
   "dbg",
   sizeof(Dbg__Request),
-  5,
+  7,
   dbg__request__field_descriptors,
   dbg__request__field_indices_by_name,
   1,  dbg__request__number_ranges,
@@ -338,7 +368,7 @@ const ProtobufCEnumDescriptor dbg__response__type__descriptor =
   dbg__response__type__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor dbg__response__field_descriptors[6] =
+static const ProtobufCFieldDescriptor dbg__response__field_descriptors[7] =
 {
   {
     "type",
@@ -412,9 +442,22 @@ static const ProtobufCFieldDescriptor dbg__response__field_descriptors[6] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "buffer",
+    7,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_BYTES,
+    offsetof(Dbg__Response, has_buffer),
+    offsetof(Dbg__Response, buffer),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned dbg__response__field_indices_by_name[] = {
   3,   /* field[3] = address */
+  6,   /* field[6] = buffer */
   2,   /* field[2] = info */
   1,   /* field[1] = msg */
   4,   /* field[4] = size */
@@ -424,7 +467,7 @@ static const unsigned dbg__response__field_indices_by_name[] = {
 static const ProtobufCIntRange dbg__response__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 6 }
+  { 0, 7 }
 };
 const ProtobufCMessageDescriptor dbg__response__descriptor =
 {
@@ -434,7 +477,7 @@ const ProtobufCMessageDescriptor dbg__response__descriptor =
   "Dbg__Response",
   "dbg",
   sizeof(Dbg__Response),
-  6,
+  7,
   dbg__response__field_descriptors,
   dbg__response__field_indices_by_name,
   1,  dbg__response__number_ranges,

--- a/dbg.pb-c.h
+++ b/dbg.pb-c.h
@@ -35,7 +35,9 @@ typedef enum _Dbg__Request__Type {
   DBG__REQUEST__TYPE__DEBUG_PRINT = 6,
   DBG__REQUEST__TYPE__SHOW_DEBUG_SCREEN = 7,
   DBG__REQUEST__TYPE__SHOW_FRONT_SCREEN = 8,
-  DBG__REQUEST__TYPE__COUNT = 9
+  DBG__REQUEST__TYPE__SCSI_DVD_IN = 9,
+  DBG__REQUEST__TYPE__SCSI_DVD_OUT = 10,
+  DBG__REQUEST__TYPE__COUNT = 11
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(DBG__REQUEST__TYPE)
 } Dbg__Request__Type;
 typedef enum _Dbg__Response__Type {
@@ -82,10 +84,14 @@ struct  _Dbg__Request
    */
   protobuf_c_boolean has_value;
   int64_t value;
+  protobuf_c_boolean has_command;
+  ProtobufCBinaryData command;
+  protobuf_c_boolean has_buffer;
+  ProtobufCBinaryData buffer;
 };
 #define DBG__REQUEST__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&dbg__request__descriptor) \
-    , 0, NULL, 0,0, 0,0, 0,0 }
+    , 0, NULL, 0,0, 0,0, 0,0, 0,{0,NULL}, 0,{0,NULL} }
 
 
 struct  _Dbg__Response
@@ -116,10 +122,12 @@ struct  _Dbg__Response
    */
   protobuf_c_boolean has_value;
   int64_t value;
+  protobuf_c_boolean has_buffer;
+  ProtobufCBinaryData buffer;
 };
 #define DBG__RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&dbg__response__descriptor) \
-    , 0, NULL, NULL, 0,0, 0,0, 0,0 }
+    , 0, NULL, NULL, 0,0, 0,0, 0,0, 0,{0,NULL} }
 
 
 /* Dbg__SysInfo methods */

--- a/dbg.proto
+++ b/dbg.proto
@@ -16,8 +16,10 @@ message Request {
 		DEBUG_PRINT       = 6;
 		SHOW_DEBUG_SCREEN = 7;
 		SHOW_FRONT_SCREEN = 8;
+    SCSI_DVD_IN       = 9;
+    SCSI_DVD_OUT      = 10;
 
-		COUNT = 9;
+		COUNT = 11;
 	}
 
 	required Type   type    = 1; //
@@ -25,6 +27,8 @@ message Request {
 	optional int32  address = 3; // FREE, MEM_READ, MEM_WRITE
 	optional int32  size    = 4; // MALLOC, MEM_READ, MEM_WRITE
 	optional int64  value   = 5; // MEM_WRITE
+  optional bytes  command = 6;
+  optional bytes  buffer  = 7;
 }
 
 message Response {
@@ -40,4 +44,5 @@ message Response {
 	optional int32   address = 4; // MALLOC
 	optional int32   size    = 5; // 
 	optional int64   value   = 6; // MEM_READ
+  optional bytes   buffer  = 7;
 }

--- a/dbg.py
+++ b/dbg.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import socket
 from dbg_pb2 import *
 import time
@@ -90,12 +92,13 @@ class Xbox(object):
 
 def main():
 	xbox = Xbox()
-	addr = ("127.0.0.1", 8080)
+	#addr = ("127.0.0.1", 8080)
+	addr = ("192.168.177.2", 80)
 	# addr = ("10.0.1.14", 80)
 
 	# Connect to the Xbox, display system info
 	xbox.connect(addr)
-	print xbox.info()
+	print(xbox.info())
 
 	# Print something to the screen
 	xbox.debug_print("Hello!")
@@ -103,7 +106,7 @@ def main():
 	# Allocate, write, read-back, free
 	addr = xbox.malloc(1024)
 	val = 0x5A
-	print "Allocated memory at 0x%x" % addr
+	print("Allocated memory at 0x%x" % addr)
 	xbox.mem(addr, val)
 	assert(xbox.mem(addr) == val)
 	xbox.free(addr)

--- a/dbg.py
+++ b/dbg.py
@@ -90,6 +90,20 @@ class Xbox(object):
 		req.type = Request.SHOW_FRONT_SCREEN
 		return self._send_simple_request(req)
 
+	def scsi_dvd(self, command, _buffer=None, size=0):
+		"""Send an SCSI command to the DVD drive"""
+		req = Request()
+		req.command = command
+		if _buffer:
+			#FIXME: Assert that size is 0?
+			req.type = Request.SCSI_DVD_OUT
+			req.buffer = _buffer
+		else:
+			req.type = Request.SCSI_DVD_IN
+			req.size = size
+		res = self._send_simple_request(req)
+		return res if _buffer else res.buffer
+
 def main():
 	xbox = Xbox()
 	#addr = ("127.0.0.1", 8080)
@@ -100,18 +114,115 @@ def main():
 	xbox.connect(addr)
 	print(xbox.info())
 
-	# Print something to the screen
-	xbox.debug_print("Hello!")
+	#print(xbox.scsi_dvd(bytes([0x12,0x00,0x00,0x00,36+100,0x00]), size=36 + 100)) # INQUIRY [Does not work for my drive?!]
+
+	def mode_sense():
+		#FIXME: Make a more generic mode_sense
+		action = 0
+		code = 0x3E
+		# req_b = bytes([0x5A, 0x00, (action << 6) | (code & 0x3F), 0x00, 0x00, 0x00, 0x00, (length >> 8) & 0xFF, length & 0xFF, 0x00])
+		# print(' 0x'.join(format(x, '02x') for x in req_b))
+
+
+	# Get mode page
+	length = (20+8) # Length of auth page + mode sense header
+	req_b = bytes([0x5A, 0x00, 0x3E, 0x00, 0x00, 0x00, 0x00, (length >> 8) & 0xFF, length & 0xFF, 0x00])
+	#print(' 0x'.join(format(x, '02x') for x in req_b))
+	res_b = xbox.scsi_dvd(req_b, size=length)
+	#print(' 0x'.join(format(x, '02x') for x in res_b))
+
+	def read8(b):
+		return b.pop(0)
+
+	def read32(b):
+		x0 = read8(b)
+		x1 = read8(b)
+		x2 = read8(b)
+		x3 = read8(b)
+		return (x3 << 24) | (x2 << 16) | (x1 << 8) | x0
+
+	res = list(res_b)
+
+	# Pop off the MODE_SENSE header
+	read8(res)
+	read8(res)
+	read8(res)
+	read8(res)
+	read8(res)
+	read8(res)
+	read8(res)
+	read8(res)
+
+	print(res)
+
+	d = {}
+	#d['wtfthisshouldbehere'] = read8(res) # No idea what this is?!
+
+	d['mode_page'] = read8(res)
+	d['length'] = read8(res) #	Excluding this & the field before. Should always be 18
+	d['partition_select'] = read8(res) # 0x00 = Video partition
+	                                   # 0x01 = Xbox partition
+	                                   #
+	                                   # This will be set to 0x01 by the kernel when the last challenge was verified. This is done by sending the same challenge again, the challenge id / value is not reset.
+	d['unknown0'] = read8(res) # If this is not 1, the kernel will reject this as an XGD (but still allow normal access?![citation needed])
+	d['authenticated'] = read8(res) # 0x00 = Not authenticated
+	                                # 0x01 = Already authenticated | authentication in progress
+	                                #
+	                                # This will be set to 0x01 by the kernel when the first challenge is send.
+	tmp = read8(res)
+	d['booktype'] = (tmp >> 4) & 0xF # Booktype 0xD is used for Xbox games. This must match info from the SS.
+	d['bookversion'] = tmp & 0xF
+	d['unknown1'] = read8(res) # ?
+	d['challenge_id'] = read8(res)
+	d['challenge_value'] = read32(res)
+	d['response_value'] = read32(res)
+	d['unknown2'] = read8(res) #Unused?
+	d['unknown3'] = read8(res) #Unused?
+	d['unknown4'] = read8(res) # Unused?
+	d['unknown5'] = read8(res) # Unused?
+
+	print(d)
+
+
+	# Mode select
+
+	length = (20+8) # Length of auth page + mode select header
+	# Somehow xbox uses a mode sense 10 like-structure but uses mode select 10 ?
+	req_b = bytes([0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (length >> 8) & 0xFF, length & 0xFF, 0x00])
+	#header_b = bytes([0, 0x1A, 0, 0, 0, 0, 0, 0])
+	header_b = bytes([0, 0x00, 0, 0, 0, 0, 0, 0])
+#	data_b = bytes([0x3E, 18, 0, 1, 1, 0xD1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]) # Authenticate and select video partition
+#	data_b = bytes([0x3E, 18, 1, 1, 1, 0xD1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]) # Authenticate and select xbox partition
+	
+	#print(' 0x'.join(format(x, '02x') for x in req_b))
+	res_b = xbox.scsi_dvd(req_b, header_b + data_b)
+
+
+
+	length = 254 # Must be even + can't be larger than 255 because of NXDK / etherforce / lwip fuckup
+	#print(xbox.scsi_dvd(bytes([0xad, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (length >> 8) & 0xFF, length & 0xFF, 0x00, 0xc0]), size=length)) # Get PFI
+	#print(xbox.scsi_dvd(bytes([0xad, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, (length >> 8) & 0xFF, length & 0xFF, 0x00, 0xc0]), size=length)) # Get DMI
+	#print(xbox.scsi_dvd(bytes([0xad, 0x00, 0xff, 0x02, 0xfd, 0xff, 0xfe, 0x00, (length >> 8) & 0xFF, length & 0xFF, 0x00, 0xc0]), size=length)) # Get SS
+	#                            ad                                                                   << Operation (Read DVD Structure)
+	#                                  00                                                             << Media Type & such
+	#                                        ff    02    fd    ff                                     << Block
+	#                                                                fe                               << Layer
+	#                                                                      00                         << Format code (Physical descriptor)
+	#                                                                            06    64             << Length (0x664 = 1636)
+	#                                                                                        00       << AGID etc.
+	#                                                                                              c0 << Control [Vendor specific]
+
+#	print(xbox.scsi_dvd(bytes([0x12,0x00,0x00,0x08,0x00,0xC0]), bytes([]))) # No idea.. my philips drive won't respect any message anyway
+
 
 	# Allocate, write, read-back, free
-	addr = xbox.malloc(1024)
-	val = 0x5A
-	print("Allocated memory at 0x%x" % addr)
-	xbox.mem(addr, val)
-	assert(xbox.mem(addr) == val)
-	xbox.free(addr)
+	#addr = xbox.malloc(1024)
+	#val = 0x5A
+	#print("Allocated memory at 0x%x" % addr)
+	#xbox.mem(addr, val)
+	#assert(xbox.mem(addr) == val)
+	#xbox.free(addr)
 	
-	#xbox.reboot()
 	xbox.disconnect()
 
 if __name__ == '__main__':

--- a/dbg_pb2.py
+++ b/dbg_pb2.py
@@ -18,9 +18,9 @@ _sym_db = _symbol_database.Default()
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='dbg.proto',
   package='dbg',
-  serialized_pb=_b('\n\tdbg.proto\x12\x03\x64\x62g\"\x1d\n\x07SysInfo\x12\x12\n\ntick_count\x18\x01 \x02(\x03\"\x84\x02\n\x07Request\x12\x1f\n\x04type\x18\x01 \x02(\x0e\x32\x11.dbg.Request.Type\x12\x0b\n\x03msg\x18\x02 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x03 \x01(\x05\x12\x0c\n\x04size\x18\x04 \x01(\x05\x12\r\n\x05value\x18\x05 \x01(\x03\"\x9c\x01\n\x04Type\x12\x0b\n\x07SYSINFO\x10\x00\x12\n\n\x06REBOOT\x10\x01\x12\n\n\x06MALLOC\x10\x02\x12\x08\n\x04\x46REE\x10\x03\x12\x0c\n\x08MEM_READ\x10\x04\x12\r\n\tMEM_WRITE\x10\x05\x12\x0f\n\x0b\x44\x45\x42UG_PRINT\x10\x06\x12\x15\n\x11SHOW_DEBUG_SCREEN\x10\x07\x12\x15\n\x11SHOW_FRONT_SCREEN\x10\x08\x12\t\n\x05\x43OUNT\x10\t\"\xc8\x01\n\x08Response\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.dbg.Response.Type\x12\x0b\n\x03msg\x18\x02 \x01(\t\x12\x1a\n\x04info\x18\x03 \x01(\x0b\x32\x0c.dbg.SysInfo\x12\x0f\n\x07\x61\x64\x64ress\x18\x04 \x01(\x05\x12\x0c\n\x04size\x18\x05 \x01(\x05\x12\r\n\x05value\x18\x06 \x01(\x03\"C\n\x04Type\x12\x06\n\x02OK\x10\x00\x12\x15\n\x11\x45RROR_UNSUPPORTED\x10\x01\x12\x1c\n\x18\x45RROR_INCOMPLETE_REQUEST\x10\x02')
+  syntax='proto2',
+  serialized_pb=_b('\n\tdbg.proto\x12\x03\x64\x62g\"\x1d\n\x07SysInfo\x12\x12\n\ntick_count\x18\x01 \x02(\x03\"\xc8\x02\n\x07Request\x12\x1f\n\x04type\x18\x01 \x02(\x0e\x32\x11.dbg.Request.Type\x12\x0b\n\x03msg\x18\x02 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x03 \x01(\x05\x12\x0c\n\x04size\x18\x04 \x01(\x05\x12\r\n\x05value\x18\x05 \x01(\x03\x12\x0f\n\x07\x63ommand\x18\x06 \x01(\x0c\x12\x0e\n\x06\x62uffer\x18\x07 \x01(\x0c\"\xbf\x01\n\x04Type\x12\x0b\n\x07SYSINFO\x10\x00\x12\n\n\x06REBOOT\x10\x01\x12\n\n\x06MALLOC\x10\x02\x12\x08\n\x04\x46REE\x10\x03\x12\x0c\n\x08MEM_READ\x10\x04\x12\r\n\tMEM_WRITE\x10\x05\x12\x0f\n\x0b\x44\x45\x42UG_PRINT\x10\x06\x12\x15\n\x11SHOW_DEBUG_SCREEN\x10\x07\x12\x15\n\x11SHOW_FRONT_SCREEN\x10\x08\x12\x0f\n\x0bSCSI_DVD_IN\x10\t\x12\x10\n\x0cSCSI_DVD_OUT\x10\n\x12\t\n\x05\x43OUNT\x10\x0b\"\xd8\x01\n\x08Response\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.dbg.Response.Type\x12\x0b\n\x03msg\x18\x02 \x01(\t\x12\x1a\n\x04info\x18\x03 \x01(\x0b\x32\x0c.dbg.SysInfo\x12\x0f\n\x07\x61\x64\x64ress\x18\x04 \x01(\x05\x12\x0c\n\x04size\x18\x05 \x01(\x05\x12\r\n\x05value\x18\x06 \x01(\x03\x12\x0e\n\x06\x62uffer\x18\x07 \x01(\x0c\"C\n\x04Type\x12\x06\n\x02OK\x10\x00\x12\x15\n\x11\x45RROR_UNSUPPORTED\x10\x01\x12\x1c\n\x18\x45RROR_INCOMPLETE_REQUEST\x10\x02')
 )
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -67,14 +67,22 @@ _REQUEST_TYPE = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='COUNT', index=9, number=9,
+      name='SCSI_DVD_IN', index=9, number=9,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='SCSI_DVD_OUT', index=10, number=10,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='COUNT', index=11, number=11,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=154,
-  serialized_end=310,
+  serialized_start=187,
+  serialized_end=378,
 )
 _sym_db.RegisterEnumDescriptor(_REQUEST_TYPE)
 
@@ -99,8 +107,8 @@ _RESPONSE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=446,
-  serialized_end=513,
+  serialized_start=530,
+  serialized_end=597,
 )
 _sym_db.RegisterEnumDescriptor(_RESPONSE_TYPE)
 
@@ -127,6 +135,7 @@ _SYSINFO = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
   oneofs=[
   ],
@@ -177,6 +186,20 @@ _REQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='command', full_name='dbg.Request.command', index=5,
+      number=6, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='buffer', full_name='dbg.Request.buffer', index=6,
+      number=7, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -186,11 +209,12 @@ _REQUEST = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
   oneofs=[
   ],
   serialized_start=50,
-  serialized_end=310,
+  serialized_end=378,
 )
 
 
@@ -243,6 +267,13 @@ _RESPONSE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='buffer', full_name='dbg.Response.buffer', index=6,
+      number=7, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -252,11 +283,12 @@ _RESPONSE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=313,
-  serialized_end=513,
+  serialized_start=381,
+  serialized_end=597,
 )
 
 _REQUEST.fields_by_name['type'].enum_type = _REQUEST_TYPE
@@ -267,6 +299,7 @@ _RESPONSE_TYPE.containing_type = _RESPONSE
 DESCRIPTOR.message_types_by_name['SysInfo'] = _SYSINFO
 DESCRIPTOR.message_types_by_name['Request'] = _REQUEST
 DESCRIPTOR.message_types_by_name['Response'] = _RESPONSE
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 SysInfo = _reflection.GeneratedProtocolMessageType('SysInfo', (_message.Message,), dict(
   DESCRIPTOR = _SYSINFO,

--- a/dbgd.c
+++ b/dbgd.c
@@ -22,6 +22,7 @@
 
 #include "dbg.pb-c.h"
 #include "net.h"
+#include "scsi.h"
 #include "dbgd.h"
 
 #define DBGD_PORT 80
@@ -250,3 +251,27 @@ static int dbgd_show_front_screen(Dbg__Request *req, Dbg__Response *res)
 
     return DBG__RESPONSE__TYPE__OK;
 }
+
+static int dbgd_scsi_dvd_in(Dbg__Request *req, Dbg__Response *res)
+{
+    if (!req->has_command || !req->has_size)
+        return DBG__RESPONSE__TYPE__ERROR_INCOMPLETE_REQUEST;
+
+    res->buffer.len  = req->size; 
+    res->buffer.data = malloc(res->buffer.len);
+    res->has_buffer = 1;
+    NTSTATUS status = scsi_dvd_command(SCSI_IOCTL_DATA_IN, req->command.data, req->command.len, res->buffer.data, res->buffer.len);
+
+    return DBG__RESPONSE__TYPE__OK;
+}
+
+static int dbgd_scsi_dvd_out(Dbg__Request *req, Dbg__Response *res)
+{
+    if (!req->has_command || !req->has_buffer)
+        return DBG__RESPONSE__TYPE__ERROR_INCOMPLETE_REQUEST;
+
+    NTSTATUS status = scsi_dvd_command(SCSI_IOCTL_DATA_OUT, req->command.data, req->command.len, req->buffer.data, req->buffer.len);
+
+    return DBG__RESPONSE__TYPE__OK;
+}
+

--- a/dbgd.c
+++ b/dbgd.c
@@ -31,28 +31,8 @@
 #define HTTPD_DEBUG LWIP_DBG_OFF
 #endif
 
-static int dbgd_sysinfo(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_reboot(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_malloc(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_free(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_mem_read(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_mem_write(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_debug_print(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_show_debug_screen(Dbg__Request *req, Dbg__Response *res);
-static int dbgd_show_front_screen(Dbg__Request *req, Dbg__Response *res);
-
 typedef int (*dbgd_req_handler)(Dbg__Request *req, Dbg__Response *res);
-static dbgd_req_handler handlers[DBG__REQUEST__TYPE__COUNT] = {
-    &dbgd_sysinfo,
-    &dbgd_reboot,
-    &dbgd_malloc,
-    &dbgd_free,
-    &dbgd_mem_read,
-    &dbgd_mem_write,
-    &dbgd_debug_print,
-    &dbgd_show_debug_screen,
-    &dbgd_show_front_screen,
-};
+extern dbgd_req_handler handlers[DBG__REQUEST__TYPE__COUNT];
 
 static void dbgd_serve(struct netconn *conn)
 {
@@ -259,6 +239,7 @@ static int dbgd_scsi_dvd_in(Dbg__Request *req, Dbg__Response *res)
 
     res->buffer.len  = req->size; 
     res->buffer.data = malloc(res->buffer.len);
+    memset(res->buffer.data, 0xFF, res->buffer.len);
     res->has_buffer = 1;
     NTSTATUS status = scsi_dvd_command(SCSI_IOCTL_DATA_IN, req->command.data, req->command.len, res->buffer.data, res->buffer.len);
 
@@ -274,4 +255,20 @@ static int dbgd_scsi_dvd_out(Dbg__Request *req, Dbg__Response *res)
 
     return DBG__RESPONSE__TYPE__OK;
 }
+
+
+static dbgd_req_handler handlers[DBG__REQUEST__TYPE__COUNT] = {
+    &dbgd_sysinfo,
+    &dbgd_reboot,
+    &dbgd_malloc,
+    &dbgd_free,
+    &dbgd_mem_read,
+    &dbgd_mem_write,
+    &dbgd_debug_print,
+    &dbgd_show_debug_screen,
+    &dbgd_show_front_screen,
+    &dbgd_scsi_dvd_in,
+    &dbgd_scsi_dvd_out
+};
+
 

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -1,6 +1,0 @@
-#ifndef ASSERT_H
-#define ASSERT_H
-
-#define assert(x)
-
-#endif

--- a/net.c
+++ b/net.c
@@ -21,7 +21,7 @@
 
 #include "net.h"
 
-#define USE_DHCP         1
+#define USE_DHCP         0
 #define PKT_TMR_INTERVAL 5 /* ms */
 #define DEBUGGING        0
 
@@ -52,8 +52,8 @@ int net_init(void)
     IP4_ADDR(&ipaddr, 0,0,0,0);
     IP4_ADDR(&netmask, 0,0,0,0);
 #else
-    IP4_ADDR(&gw, 10,0,1,1);
-    IP4_ADDR(&ipaddr, 10,0,1,7);
+    IP4_ADDR(&gw, 192,168,177,2);
+    IP4_ADDR(&ipaddr, 192,168,177,2);
     IP4_ADDR(&netmask, 255,255,255,0);
 #endif
 

--- a/reboot.py
+++ b/reboot.py
@@ -1,0 +1,120 @@
+#!/bin/env python3
+
+import socket
+from dbg_pb2 import *
+import time
+
+class XboxError(Exception):
+	def __init__(self, msg):
+		self.msg = msg
+
+	def __str__(self):
+		return self.msg
+
+class Xbox(object):
+	def __init__(self):
+		self._sock = None
+
+	def connect(self, addr):
+		"""Connect to the Xbox"""
+		self._sock = socket.create_connection(addr, 5)
+
+	def disconnect(self):
+		"""Disconnect from the Xbox"""
+		self._sock.close()
+		self._sock = None
+
+	def _send_simple_request(self, req):
+		"""Send a simple request, expect success"""
+		self._sock.send(req.SerializeToString())
+		res = Response()
+		res.ParseFromString(self._sock.recv(4096))
+		if res.type != Response.OK:
+			raise XboxError(res.msg)
+		return res
+
+	def info(self):
+		"""Get system info"""
+		req = Request()
+		req.type = Request.SYSINFO
+		return self._send_simple_request(req).info
+
+	def reboot(self):
+		"""Reboot the system"""
+		msg = Request()
+		msg.type = Request.REBOOT
+		self._sock.send(msg.SerializeToString())
+
+	def malloc(self, size):
+		"""Allocate memory on the target"""
+		req = Request()
+		req.type = Request.MALLOC
+		req.size = size
+		return self._send_simple_request(req).address
+
+	def free(self, addr):
+		"""Free memory on the target"""
+		req = Request()
+		req.type = Request.FREE
+		req.address = addr
+		return self._send_simple_request(req)
+
+	def mem(self, addr, value=None):
+		"""Read/write system memory"""
+		write = value is not None
+		req = Request()
+		req.type    = Request.MEM_WRITE if write else Request.MEM_READ
+		req.address = addr
+		req.size    = 1 # TODO: Support word, dword, qword accesses
+		if write:
+			req.value = value
+		res = self._send_simple_request(req)
+		return res if write else res.value
+
+	def debug_print(self, string):
+		"""Print a debug string to the screen"""
+		req = Request()
+		req.type = Request.DEBUG_PRINT
+		req.msg = string
+		return self._send_simple_request(req)
+
+	def show_debug_screen(self):
+		"""Show the debug screen"""
+		req = Request()
+		req.type = Request.SHOW_DEBUG_SCREEN
+		return self._send_simple_request(req)
+
+	def show_front_screen(self):
+		"""Show the front screen"""
+		req = Request()
+		req.type = Request.SHOW_FRONT_SCREEN
+		return self._send_simple_request(req)
+
+	def scsi_dvd(self, command, _buffer=None, size=0):
+		"""Send an SCSI command to the DVD drive"""
+		req = Request()
+		req.command = command
+		if _buffer:
+			#FIXME: Assert that size is 0?
+			req.type = Request.SCSI_DVD_OUT
+			req.buffer = _buffer
+		else:
+			req.type = Request.SCSI_DVD_IN
+			req.size = size
+		res = self._send_simple_request(req)
+		return res if _buffer else res.buffer
+
+def main():
+	xbox = Xbox()
+	#addr = ("127.0.0.1", 8080)
+	addr = ("192.168.177.2", 80)
+	# addr = ("10.0.1.14", 80)
+
+	# Connect to the Xbox, display system info
+	xbox.connect(addr)
+
+	xbox.reboot()
+	xbox.disconnect()
+
+if __name__ == '__main__':
+	main()

--- a/scsi.c
+++ b/scsi.c
@@ -1,0 +1,48 @@
+#include <xboxkrnl/xboxkrnl.h>
+
+#include "scsi.h"
+
+static PDEVICE_OBJECT get_dvd_device_object(void)
+{
+    static PDEVICE_OBJECT device = NULL;
+
+    if (device == NULL) {
+	      ANSI_STRING cdrom;  
+        RtlInitAnsiString(&cdrom, "\\Device\\Cdrom0");
+
+        // Get a reference to the dvd object so that we can query it for info.
+        NTSTATUS status = ObReferenceObjectByName(&cdrom, 0, &IoDeviceObjectType, NULL, (void**)&device);
+
+	      if (!NT_SUCCESS(status)) {
+            return NULL;
+        }
+
+        assert(device != NULL);
+    }
+
+    return device;
+}
+
+NTSTATUS scsi_dvd_command(UCHAR data_in, const void* command, size_t command_length, const void* buffer, size_t buffer_length)
+{
+    PDEVICE_OBJECT device = get_dvd_device_object();
+    assert(device != NULL);
+
+    SCSI_PASS_THROUGH_DIRECT pass_through;
+    RtlZeroMemory(&pass_through, sizeof(SCSI_PASS_THROUGH_DIRECT));
+
+    pass_through.Length = sizeof(SCSI_PASS_THROUGH_DIRECT);
+    pass_through.DataIn = data_in;
+    pass_through.DataBuffer = buffer;
+    pass_through.DataTransferLength = buffer_length;
+
+    assert(command_length <= sizeof(pass_through.Cdb));
+    memcpy(&pass_through.Cdb, command, command_length);
+
+    NTSTATUS status = IoSynchronousDeviceIoControlRequest(IOCTL_SCSI_PASS_THROUGH_DIRECT,
+                          device, &pass_through, sizeof(SCSI_PASS_THROUGH_DIRECT),
+                          NULL, 0, NULL, FALSE);
+
+    return status;
+}
+

--- a/scsi.c
+++ b/scsi.c
@@ -23,25 +23,34 @@ static PDEVICE_OBJECT get_dvd_device_object(void)
     return device;
 }
 
-NTSTATUS scsi_dvd_command(UCHAR data_in, const void* command, size_t command_length, const void* buffer, size_t buffer_length)
+NTSTATUS scsi_dvd_command(UCHAR data_in, const void* command, size_t command_length, void* buffer, size_t buffer_length)
 {
     PDEVICE_OBJECT device = get_dvd_device_object();
     assert(device != NULL);
+//debugPrint("device: %d\n", device);
+//debugPrint("size: %d\n", sizeof(SCSI_PASS_THROUGH_DIRECT));
 
     SCSI_PASS_THROUGH_DIRECT pass_through;
-    RtlZeroMemory(&pass_through, sizeof(SCSI_PASS_THROUGH_DIRECT));
+    memset(&pass_through, 0x00, sizeof(SCSI_PASS_THROUGH_DIRECT));
 
     pass_through.Length = sizeof(SCSI_PASS_THROUGH_DIRECT);
     pass_through.DataIn = data_in;
-    pass_through.DataBuffer = buffer;
+    pass_through.DataBuffer = (PVOID)buffer;
     pass_through.DataTransferLength = buffer_length;
 
     assert(command_length <= sizeof(pass_through.Cdb));
-    memcpy(&pass_through.Cdb, command, command_length);
+    memcpy(pass_through.Cdb, command, command_length);
+    //pass_through.CdbLength = command_length;
+
+//for(int i = 0; i < command_length; i++) {
+//  debugPrint("%d\n", pass_through.Cdb[i]);
+//}
 
     NTSTATUS status = IoSynchronousDeviceIoControlRequest(IOCTL_SCSI_PASS_THROUGH_DIRECT,
-                          device, &pass_through, sizeof(SCSI_PASS_THROUGH_DIRECT),
-                          NULL, 0, NULL, FALSE);
+                          device, &pass_through, sizeof(pass_through),
+                          NULL, 0, /* &output_length */ NULL, FALSE);
+
+debugPrint("status: %d\n", status);
 
     return status;
 }

--- a/scsi.c
+++ b/scsi.c
@@ -1,4 +1,7 @@
 #include <xboxkrnl/xboxkrnl.h>
+#include <xboxrt/debug.h>
+#include <string.h>
+#include <assert.h>
 
 #include "scsi.h"
 

--- a/scsi.h
+++ b/scsi.h
@@ -1,0 +1,15 @@
+#ifndef SCSI_H
+#define SCSI_H
+
+#include <xboxkrnl/xboxkrnl.h>
+
+#define SCSI_IOCTL_DATA_OUT          	0
+#define SCSI_IOCTL_DATA_IN           	1
+#define SCSI_IOCTL_DATA_UNSPECIFIED		2
+
+#define IOCTL_SCSI_PASS_THROUGH 		    0x4D004
+#define IOCTL_SCSI_PASS_THROUGH_DIRECT	0x4D014
+
+NTSTATUS scsi_command(UCHAR data_in, const void* command, size_t command_length, const void* buffer, size_t buffer_length);
+
+#endif

--- a/scsi.h
+++ b/scsi.h
@@ -10,6 +10,6 @@
 #define IOCTL_SCSI_PASS_THROUGH 		    0x4D004
 #define IOCTL_SCSI_PASS_THROUGH_DIRECT	0x4D014
 
-NTSTATUS scsi_command(UCHAR data_in, const void* command, size_t command_length, const void* buffer, size_t buffer_length);
+NTSTATUS scsi_dvd_command(UCHAR data_in, const void* command, size_t command_length, void* buffer, size_t buffer_length);
 
 #endif


### PR DESCRIPTION
The reason for working on this is that I currently try to get the XGD authentication in XQEMU right. However, the hashes for my kreon dumped DVDs don't match, so I want to see if the xbox returns different data.
In general, forwarding such commands to the original drive while testing would be nice.

---

TODO:
- Make this compilable (needs XDK work)
- Seperate the shit which was necessary to make nxdk-rdt work locally
- Write an example script
- Testing.. lots and lots of testing
- Rebase onto the clean + memory branch once those are merged