### PR TITLE
Cleanup the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,21 @@
 NXDK_DIR = $(CURDIR)/../nxdk
 NXDK_NET = y
 
-XBE_TITLE = triangle
+XBE_TITLE = nxdk-rdt
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(wildcard $(CURDIR)/*.c)
 SHADER_OBJS = ps.inl vs.inl
 
 SRCS += $(CURDIR)/lib/protobuf-c/protobuf-c.c
 
-CFLAGS_EXTRA += -I$(CURDIR)
-CFLAGS_EXTRA += -I$(CURDIR)/lib
+CFLAGS += -I$(CURDIR)
+CFLAGS += -I$(CURDIR)/lib
 
 include $(NXDK_DIR)/Makefile
 
-.PHONY:clean_local
-clean_local:
+.PHONY:clean-local
+clean-local: clean
 	rm -f *.inl* log.txt dump.cap main.lib
-
-clean: clean_local
 
 %_pb2.py: %.proto
 	protoc --python_out=$(CURDIR)/ $(notdir $<)


### PR DESCRIPTION
* The title in the makefile was bad. Changed to "nxdk-rdt"
* The `clean_local` target was renamed to `clean-local` (feels more Makefile'ish) and it also calls the global `clean` now instead of overwriting it (So you can actually create a clean project directory for rebuilding)
* `CFLAGS_EXTRA` was not being used by NXDK and overall it feels like `CFLAGS` should be used (Debatable)