### PR TITLE
Add CALL method

### DIFF
--- a/dbg.proto
+++ b/dbg.proto
@@ -22,9 +22,9 @@ message Request {
 
 	required Type   type    = 1; //
 	optional string msg     = 2; // DEBUG_PRINT
-	optional int32  address = 3; // FREE, MEM_READ, MEM_WRITE
-	optional int32  size    = 4; // MALLOC, MEM_READ, MEM_WRITE
-	optional int64  value   = 5; // MEM_WRITE
+	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE
+	optional uint32 size    = 4; // MALLOC, MEM_READ
+	optional bytes  data    = 5; // MEM_WRITE
 }
 
 message Response {
@@ -37,7 +37,7 @@ message Response {
 	required Type    type    = 1; //
 	optional string  msg     = 2; //
 	optional SysInfo info    = 3; // SYSINFO
-	optional int32   address = 4; // MALLOC
-	optional int32   size    = 5; // 
-	optional int64   value   = 6; // MEM_READ
+	optional uint32  address = 4; // MALLOC
+	optional uint32  size    = 5; //
+	optional bytes   data    = 6; // MEM_READ
 }

--- a/dbg.proto
+++ b/dbg.proto
@@ -25,7 +25,7 @@ message Request {
 	optional string msg     = 2; // DEBUG_PRINT
 	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE, CALL
 	optional uint32 size    = 4; // MALLOC, MEM_READ
-	optional bytes  data    = 5; // MEM_WRITE
+	optional bytes  data    = 5; // MEM_WRITE, CALL
 }
 
 message Response {
@@ -40,5 +40,5 @@ message Response {
 	optional SysInfo info    = 3; // SYSINFO
 	optional uint32  address = 4; // MALLOC
 	optional uint32  size    = 5; //
-	optional bytes   data    = 6; // MEM_READ
+	optional bytes   data    = 6; // MEM_READ, CALL
 }

--- a/dbg.proto
+++ b/dbg.proto
@@ -16,13 +16,14 @@ message Request {
 		DEBUG_PRINT       = 6;
 		SHOW_DEBUG_SCREEN = 7;
 		SHOW_FRONT_SCREEN = 8;
+		CALL              = 9;
 
-		COUNT = 9;
+		COUNT = 10;
 	}
 
 	required Type   type    = 1; //
 	optional string msg     = 2; // DEBUG_PRINT
-	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE
+	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE, CALL
 	optional uint32 size    = 4; // MALLOC, MEM_READ
 	optional bytes  data    = 5; // MEM_WRITE
 }

--- a/dbg.py
+++ b/dbg.py
@@ -93,17 +93,15 @@ class Xbox(object):
 		req.type = Request.SHOW_FRONT_SCREEN
 		return self._send_simple_request(req)
 
-  def call(self, address, stack, registers=None):
-	  """Call a function with given context"""
-	  req = Request()
-	  req.type = Request.CALL
-	  req.address = address
-	  req.data = stack
-	  #FIXME: req.registers = registers
-	  res = self._send_simple_request(req)
-	  out_registers = {}
-	  out_registers['eax'] = res.address
-	  return out_registers
+	def call(self, address, stack, registers=None):
+		"""Call a function with given context"""
+		req = Request()
+		req.type = Request.CALL
+		req.address = address
+		req.data = stack
+		res = self._send_simple_request(req)
+		eax = struct.unpack_from("<I", res.data, 7*4)[0]
+		return eax
 
 
 def main():

--- a/dbg.py
+++ b/dbg.py
@@ -93,6 +93,19 @@ class Xbox(object):
 		req.type = Request.SHOW_FRONT_SCREEN
 		return self._send_simple_request(req)
 
+  def call(self, address, stack, registers=None):
+	  """Call a function with given context"""
+	  req = Request()
+	  req.type = Request.CALL
+	  req.address = address
+	  req.data = stack
+	  #FIXME: req.registers = registers
+	  res = self._send_simple_request(req)
+	  out_registers = {}
+	  out_registers['eax'] = res.address
+	  return out_registers
+
+
 def main():
 
 	if (len(sys.argv) != 2):

--- a/dbg.py
+++ b/dbg.py
@@ -58,17 +58,19 @@ class Xbox(object):
 		req.address = addr
 		return self._send_simple_request(req)
 
-	def mem(self, addr, value=None):
+	def mem(self, addr, size=0, data=None):
 		"""Read/write system memory"""
-		write = value is not None
+		write = data is not None
 		req = Request()
-		req.type    = Request.MEM_WRITE if write else Request.MEM_READ
-		req.address = addr
-		req.size    = 1 # TODO: Support word, dword, qword accesses
 		if write:
-			req.value = value
+			req.type = Request.MEM_WRITE
+			req.data = data
+		else:
+			req.type = Request.MEM_READ
+			req.size = size
+		req.address = addr
 		res = self._send_simple_request(req)
-		return res if write else res.value
+		return res if write else res.data
 
 	def debug_print(self, string):
 		"""Print a debug string to the screen"""
@@ -109,8 +111,8 @@ def main():
 	addr = xbox.malloc(1024)
 	val = 0x5A
 	print("Allocated memory at 0x%x" % addr)
-	xbox.mem(addr, val)
-	assert(xbox.mem(addr) == val)
+	xbox.mem(addr, data=bytes([val]))
+	assert(xbox.mem(addr, size=1)[0] == val)
 	xbox.free(addr)
 	
 	#xbox.reboot()

--- a/dbg.py
+++ b/dbg.py
@@ -58,19 +58,21 @@ class Xbox(object):
 		req.address = addr
 		return self._send_simple_request(req)
 
-	def mem(self, addr, size=0, data=None):
-		"""Read/write system memory"""
-		write = data is not None
+	def mem_read(self, addr, size):
+		"""read memory"""
 		req = Request()
-		if write:
-			req.type = Request.MEM_WRITE
-			req.data = data
-		else:
-			req.type = Request.MEM_READ
-			req.size = size
+		req.type = Request.MEM_READ
+		req.size = size
 		req.address = addr
-		res = self._send_simple_request(req)
-		return res if write else res.data
+		return self._send_simple_request(req).data
+
+	def mem_write(self, addr, data):
+		"""write memory"""
+		req = Request()
+		req.type = Request.MEM_WRITE
+		req.data = data
+		req.address = addr
+		return self._send_simple_request(req)
 
 	def debug_print(self, string):
 		"""Print a debug string to the screen"""
@@ -111,8 +113,8 @@ def main():
 	addr = xbox.malloc(1024)
 	val = 0x5A
 	print("Allocated memory at 0x%x" % addr)
-	xbox.mem(addr, data=bytes([val]))
-	assert(xbox.mem(addr, size=1)[0] == val)
+	xbox.mem_write(addr, bytes([val]))
+	assert(xbox.mem_read(addr, 1)[0] == val)
 	xbox.free(addr)
 	
 	#xbox.reboot()

--- a/dbgd.c
+++ b/dbgd.c
@@ -53,6 +53,7 @@ static int dbgd_mem_write(Dbg__Request *req, Dbg__Response *res);
 static int dbgd_debug_print(Dbg__Request *req, Dbg__Response *res);
 static int dbgd_show_debug_screen(Dbg__Request *req, Dbg__Response *res);
 static int dbgd_show_front_screen(Dbg__Request *req, Dbg__Response *res);
+static int dbgd_call(Dbg__Request *req, Dbg__Response *res);
 
 typedef int (*dbgd_req_handler)(Dbg__Request *req, Dbg__Response *res);
 static dbgd_req_handler handlers[DBG__REQUEST__TYPE__COUNT] = {
@@ -65,6 +66,7 @@ static dbgd_req_handler handlers[DBG__REQUEST__TYPE__COUNT] = {
     &dbgd_debug_print,
     &dbgd_show_debug_screen,
     &dbgd_show_front_screen,
+    &dbgd_call
 };
 
 static void dbgd_serve(struct netconn *conn)
@@ -296,5 +298,83 @@ static int dbgd_show_front_screen(Dbg__Request *req, Dbg__Response *res)
 {
     pb_show_front_screen();
 
+    return DBG__RESPONSE__TYPE__OK;
+}
+
+static __attribute__((__stdcall__)) uint32_t test(uint32_t a, uint32_t b) {
+  debugPrint("test(%d, %d)\n", a, b);
+  return a + b;
+}
+
+static int dbgd_call(Dbg__Request *req, Dbg__Response *res)
+{
+    if (!req->has_address)
+        return DBG__RESPONSE__TYPE__ERROR_INCOMPLETE_REQUEST;
+
+    size_t stack_size = 0x1000;
+    uint8_t* stack_data = (uint8_t*)malloc(stack_size); // FIXME: Calculate correct size
+
+    static uint32_t stack_pointer;
+    static uint32_t stack_backup;
+    static uint32_t address;
+ 
+    stack_pointer = (uint32_t)&stack_data[stack_size];
+    address = req->address;
+
+    // Push stack contents
+
+    if (req->has_data) {
+      stack_pointer -= req->data.len;
+      memcpy((void*)stack_pointer, req->data.data, req->data.len);
+    }
+
+    // This is where the call will happen
+
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // EAX
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // ECX
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // EDX
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // EBX
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // ESP (Will be ignored)
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // EBP
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // ESI
+    stack_pointer -= 4;
+    *(uint32_t*)(stack_pointer) = 0; // EDI
+
+    asm("pusha\n"
+        "mov %%esp, %[stack_backup]\n" // Keep copy of original stack
+
+        "mov %[stack_pointer], %%esp\n"
+        "popa\n" // Load all registers
+
+        "call *%[address]\n" // Call the function
+
+        "mov %[stack_pointer], %%esp\n" // push all register values to stack
+        "add $32, %%esp\n"
+        "pusha\n"
+
+        "mov %[stack_backup], %%esp\n" // Recover original stack
+        "popa\n"
+
+        : // No outputs
+        : [stack_pointer] "m" (stack_pointer),
+          [stack_backup]  "m" (stack_backup),
+          [address]       "m" (address)
+        : "memory");
+
+    uint32_t eax = *(uint32_t*)(stack_pointer + 7*4);
+
+    //FIXME: Move to a new var instead!
+    res->has_address = 1;
+    res->address = eax;  
+
+    free(stack_data);
+  
     return DBG__RESPONSE__TYPE__OK;
 }

--- a/dbgd.c
+++ b/dbgd.c
@@ -30,6 +30,20 @@
 #define HTTPD_DEBUG LWIP_DBG_OFF
 #endif
 
+static void* get_transfer_buffer(uint32_t size) {
+    static uint32_t buffer_size = 0;
+    static void* buffer = NULL;
+
+    if (size > buffer_size) {
+        if (buffer != NULL) {
+            free(buffer);
+        }
+        buffer = malloc(size);
+        buffer_size = size;
+    }
+    return buffer;
+}
+
 static int dbgd_sysinfo(Dbg__Request *req, Dbg__Response *res);
 static int dbgd_reboot(Dbg__Request *req, Dbg__Response *res);
 static int dbgd_malloc(Dbg__Request *req, Dbg__Response *res);
@@ -212,7 +226,7 @@ static int dbgd_mem_read(Dbg__Request *req, Dbg__Response *res)
     res->has_address = 1;
 
     res->data.len  = req->size;
-    res->data.data = malloc(res->data.len);
+    res->data.data = get_transfer_buffer(res->data.len);
     res->has_data = 1;
 
     unsigned int i = 0;


### PR DESCRIPTION
This implements a way of doing calls using the CPU on the remote.

The following API / design has been chosen:

- Stack data can be supplied which will run the virtual CPU, additionally, the virtual stack has 4096 more bytes, which should be enough for most tasks.

    *If that stack is not enough, the called function can set its own stack, because the real stack is always restored automatically on exit.*

- `pusha` and `popa` protect real register values. Float or special registers are not restored.

- No registers are controlled on entry.

    *The original code for this had a feature where the CALL controlled *every* register on entry. However Xbox mostly uses stdcall or cdecl, and passing all registers was slower and not beneficial in those cases.*

    *If anyone needs registers on entry, they can inject their own CALL handler which pops register values from the virtual stack. Each connection would probably allocate their own helper and might not `free` it correctly either; problem?*

- The return value is currently a bytes object containing the memory layout of a `pusha`.

    *Done to keep the documentation simple. Not a big fan of this design, because transfers lots of memory, even for simple functions. Most functions / conventions only care about EAX and EDX, so I'm open to discussing changes. I felt transferring only EAX and EDX felt kind of arbitrary. Also did not want to add .eax and .edx just for the CALL (but I'm open to doing that).*

I recommend that people keep their code abstract though. CALL is a complex operation and design changes in the future are possible.

There is no example provided with dbg.py (the `call` function is still defined). That is because we'd either have to do a lot of work to retrieve kernel pointers, or we'd have to inject our own function.
[xboxpy](https://github.com/XboxDev/xboxpy) and [my python-scripts](https://github.com/JayFoxRox/xbox-tools/tree/master/python-scripts) do both of these things, so if you want to learn more, look at those.
I could possibly provide a sample which injects a function to read rdtsc (which would also require EDX readback though) if a sample is absolutely necessary.


FIXME:
- Final review