### PR TITLE
Read network config from EEPROM

### DIFF
--- a/net.c
+++ b/net.c
@@ -21,7 +21,7 @@
 
 #include "net.h"
 
-#define USE_DHCP         1
+#define USE_DHCP         0
 #define PKT_TMR_INTERVAL 5 /* ms */
 #define DEBUGGING        0
 
@@ -48,13 +48,34 @@ int net_init(void)
 #endif
 
 #if USE_DHCP
-    IP4_ADDR(&gw, 0,0,0,0);
     IP4_ADDR(&ipaddr, 0,0,0,0);
     IP4_ADDR(&netmask, 0,0,0,0);
+    IP4_ADDR(&gw, 0,0,0,0);
 #else
-    IP4_ADDR(&gw, 10,0,1,1);
-    IP4_ADDR(&ipaddr, 10,0,1,7);
+    IP4_ADDR(&ipaddr, 192,168,177,3);
     IP4_ADDR(&netmask, 255,255,255,0);
+    IP4_ADDR(&gw, 192,168,177,1);
+
+// Stolen from MSDN and Cxbx. Must be moved to nxdk
+#define REG_DWORD 4
+#define XC_ONLINE_IP_ADDRESS              0xD
+#define XC_ONLINE_SUBNET_ADDRESS          0x10
+#define XC_ONLINE_DEFAULT_GATEWAY_ADDRESS 0xF
+
+    ULONG type;
+    NTSTATUS hr;
+
+    DWORD xbox_ipaddr;
+    hr = ExQueryNonVolatileSetting(XC_ONLINE_IP_ADDRESS, &type, &xbox_ipaddr, sizeof(xbox_ipaddr), NULL);
+    if (hr == STATUS_SUCCESS && type == REG_DWORD) { ip4_addr_set_u32(&ipaddr, xbox_ipaddr); }
+
+    DWORD xbox_netmask;
+    hr = ExQueryNonVolatileSetting(XC_ONLINE_SUBNET_ADDRESS, &type, &xbox_netmask, sizeof(xbox_netmask), NULL);
+    if (hr == STATUS_SUCCESS && type == REG_DWORD) { ip4_addr_set_u32(&netmask, xbox_netmask); }
+
+    DWORD xbox_gw;
+    hr = ExQueryNonVolatileSetting(XC_ONLINE_DEFAULT_GATEWAY_ADDRESS, &type, &xbox_gw, sizeof(xbox_gw), NULL);
+    if (hr == STATUS_SUCCESS && type == REG_DWORD) { ip4_addr_set_u32(&gw, xbox_gw); }
 #endif
 
     /* Initialize the TCP/IP stack. Wait for completion. */


### PR DESCRIPTION
This reads the network config from EEPROM using kernel functions.

## Problems

#### No configuration UI

I don't know how to configure it.
evox doesn't edit it, and my MS dashboard / XBL also doesn't configure it either.

#### DHCP

I have no idea if this sort of config allows turning on / off DHCP.
For now it's always assumed to be off (which is bad).

## Alternatives

XBL seems to use the data stored in the XBL config sector.
That is the first couple of sectors on "\\Device\\Harddisk0\\partition0". In order for this to work, you have to have a XBL compatible Xbox though (= updated dash), otherwise you can't configure it.

I'm still not sure where homebrew dashboards store their config (evox, avalaunch, xbmc and unleashx are probably the most interesting targets).